### PR TITLE
cache kube bin file to /tmp/kube-bin

### DIFF
--- a/kubeadm/install-kubeadm.sh
+++ b/kubeadm/install-kubeadm.sh
@@ -1,17 +1,38 @@
 #!/bin/bash
-
+set -ex
 ### install kubeadm kubelet kubectl ###
 
 Version=$1
 Version=${Version:-1.24.2}
 
+
+# 下载二进制
+TmpDir="/tmp/kube-bin/${Version}"
+mkdir -p ${TmpDir}
+
+function download(){
+    filename=$1
+    file_version=$2
+
+    if [ ! -f "${TmpDir}/${filename}" ]; then
+        echo "===========[ download ${filename} ]==========="
+        wget https://dl.k8s.io/release/v${file_version}/bin/linux/amd64/${filename} -P ${TmpDir}
+    fi
+}
+
+download kubeadm ${Version}
+download kubelet ${Version}
+download kubectl ${Version}
+
+
+# 拷贝二进制
 BinPath="/usr/bin"
 rm -f ${BinPath}/kubeadm ${BinPath}/kubelet ${BinPath}/kubectl
-wget https://dl.k8s.io/release/v${Version}/bin/linux/amd64/kubeadm -P ${BinPath}
-wget https://dl.k8s.io/release/v${Version}/bin/linux/amd64/kubelet -P ${BinPath}
-wget https://dl.k8s.io/release/v${Version}/bin/linux/amd64/kubectl -P ${BinPath}
+cp ${TmpDir}/kubeadm ${TmpDir}/kubelet ${TmpDir}/kubectl ${BinPath}
 chmod +x ${BinPath}/kubeadm ${BinPath}/kubelet ${BinPath}/kubectl
 
+
+echo "===========[ install kubelet ]==========="
 # add kubelet serivce
 cat > /lib/systemd/system/kubelet.service << EOF
 [Unit]
@@ -45,7 +66,7 @@ ExecStart=
 ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
 EOF
 
-
+# 启动kubelet服务
 systemctl daemon-reload
 systemctl enable kubelet
 systemctl restart kubelet


### PR DESCRIPTION
fixed https://github.com/huweihuang/kubeadm-scripts/issues/3

将二进制文件下载缓存到`/tmp/kube-bin`的目录，如果存在文件则不再下载。